### PR TITLE
fix typo in package name

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-    description-file = README.str
+description-file = README.str

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
- [metadata]
+[metadata]
     description-file = README.str

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='django-samart-save',
+    name='django-smart-save',
     version='0.0.6',
     description='Automatically validates when you call your model’s save()',
     author='Daniel Gatis Carrazzoni',


### PR DESCRIPTION
Just noticed that name of the package is a little off on pypi: https://pypi.python.org/pypi/django-samart-save/0.0.6

Cheers
